### PR TITLE
Adjust exported modules names

### DIFF
--- a/packages/angular-material/package.json
+++ b/packages/angular-material/package.json
@@ -9,7 +9,6 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",
     "name": "@feld-ai/jsonforms-angular-material"
-
   },
   "directories": {
     "src": "src",
@@ -36,7 +35,7 @@
     "layout",
     "customization"
   ],
-  "module": "./lib/fesm2022/jsonforms-angular-material.mjs",
+  "module": "./lib/fesm2022/feld-ai-jsonforms-angular-material.mjs",
   "typings": "./lib/index.d.ts",
   "scripts": {
     "build": "ng build",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -34,7 +34,7 @@
     "layout",
     "customization"
   ],
-  "module": "./lib/fesm2022/jsonforms-angular.mjs",
+  "module": "./lib/fesm2022/feld-ai-jsonforms-angular.mjs",
   "typings": "./lib/index.d.ts",
   "scripts": {
     "build": "node ./build-package.js",


### PR DESCRIPTION
This PR aims to:
- fix an issue `An unhandled exception occurred: Failed to resolve entry for package "@feld-ai/jsonforms-angular". The package may have incorrect main/module/exports specified in its package.json.`
- change names for `angular` and `angular-material` modules